### PR TITLE
misc/make-clippy-happier

### DIFF
--- a/hfendpoints-core/src/context.rs
+++ b/hfendpoints-core/src/context.rs
@@ -1,4 +1,4 @@
-use crate::Error;
+use crate::{EndpointResult, Error};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
 /// Store some information about the context in which the endpoint runs
@@ -6,15 +6,15 @@ use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 pub struct EndpointContext<I, O> {
     // /// Realtime information streaming about underlying resources usage of the handler
     // in_flight_tracker: Receiver<InFlightStats>,
-    ipc: UnboundedSender<(I, UnboundedSender<Result<O, Error>>)>,
+    ipc: UnboundedSender<(I, UnboundedSender<EndpointResult<O>>)>,
 }
 
 impl<I, O> EndpointContext<I, O> {
-    pub fn new(ipc: UnboundedSender<(I, UnboundedSender<Result<O, Error>>)>) -> Self {
+    pub fn new(ipc: UnboundedSender<(I, UnboundedSender<EndpointResult<O>>)>) -> Self {
         Self { ipc }
     }
 
-    pub fn schedule(&self, request: I) -> UnboundedReceiver<Result<O, Error>> {
+    pub fn schedule(&self, request: I) -> UnboundedReceiver<EndpointResult<O>> {
         let (sender, receiver) = unbounded_channel();
         if let Err(e) = self.ipc.send((request, sender)) {
             panic!("Failed to send to IPC");

--- a/hfendpoints-core/src/lib.rs
+++ b/hfendpoints-core/src/lib.rs
@@ -7,10 +7,11 @@ pub use context::EndpointContext;
 pub use endpoint::Endpoint;
 pub use handler::{wait_for_requests, Handler};
 pub use metrics::InFlightStats;
+use thiserror::Error;
 
 #[cfg(feature = "python")]
 use pyo3::PyErr;
-use thiserror::Error;
+
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -21,3 +22,7 @@ pub enum Error {
     #[error("{0}")]
     TestError(&'static str),
 }
+
+
+/// Result with predefined hfendpoints-core::Error as the Error type
+pub type EndpointResult<T> = Result<T, Error>;

--- a/hfendpoints-openai/src/lib.rs
+++ b/hfendpoints-openai/src/lib.rs
@@ -24,6 +24,7 @@ mod headers;
 pub use context::Context;
 
 type OpenAiResult<T> = Result<T, OpenAiError>;
+type RequestWithContext<I> = (I, Context);
 
 const STATUS_TAG: &str = "Status";
 const STATUS_DESC: &str = "Healthiness and monitoring of the endpoint";

--- a/hfendpoints-openai/src/lib.rs
+++ b/hfendpoints-openai/src/lib.rs
@@ -1,4 +1,5 @@
 use crate::audio::{AUDIO_DESC, AUDIO_TAG};
+use crate::embeddings::{EMBEDDINGS_DESC, EMBEDDINGS_TAG};
 use axum::http::{HeaderName, StatusCode};
 use error::OpenAiError;
 use std::fmt::Debug;
@@ -48,6 +49,7 @@ async fn health() -> StatusCode {
     tags(
         (name = STATUS_TAG, description = STATUS_DESC),
         (name = AUDIO_TAG, description = AUDIO_DESC),
+        (name = EMBEDDINGS_TAG, description = EMBEDDINGS_DESC)
     )
 )]
 struct ApiDoc;


### PR DESCRIPTION
# Summary

This Pull Request refactors the code to introduce a new type alias for error handling and context-binding in multiple modules. The EndpointResult type is introduced to standardize result types, and RequestWithContext type alias improves clarity for context-bundled requests. Changes primarily impact request handling and endpoint definitions in audio transcription, embeddings, and core logic.

## Main Changes
- Added EndpointResult<T> and RequestWithContext<I> type aliases for improved readability and standardized error/result handling.

- Refactored EndpointContext structures and function signatures to use EndpointResult and RequestWithContext in the hfendpoints-core module.

- Updated routes and handlers in audio/transcriptions and embeddings to align with the new type aliases.
- Enhanced documentation by including new tags for OpenAPI endpoints (EMBEDDINGS_DESC and EMBEDDINGS_TAG) alongside existing ones.

This refactor simplifies code readability and consistency while preserving functionality.