### PR TITLE
🔒 Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -51,18 +51,18 @@ jobs:
         run: echo "COMMIT_ID=${COMMIT_ID}" >> "$GITHUB_ENV"
 
       - name: "Setup Python"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: '3.12'
 
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: "Install hfjobs"
         run: python3 -m pip install hfjobs huggingface_hub
 
       - name: "Install hf endpoints CLI"
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: huggingface/hf-cli
           path: "./hfcli"
@@ -70,11 +70,11 @@ jobs:
           ref: 'main'
           token: ${{ secrets.HUGGINGFACE_CLI_TOKEN }}
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606  # v1
       - name: "Generate lockfile for hf endpoints CLI"
         run: cd ./hfcli && cargo generate-lockfile
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: |
             ~/.cargo/bin/
@@ -112,20 +112,20 @@ jobs:
         run: echo "Found .hfjobs folder"
 
       - name: "Docker login"
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: "Extract metadata information"
         id: metadata
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
         with:
           images: huggingface/hfendpoints-sdk
 
       - name: "Build SDK container"
         id: build_container_sdk
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           push: false
           tags: ${{ format('huggingface/hfendpoints-sdk:{0}', env.COMMIT_ID) }}
@@ -135,7 +135,7 @@ jobs:
         id: build_container_endpoint
         env:
           ENDPOINT_REPO_SHA: "latest"
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: ${{ env.ENDPOINT_REPO_PATH }}
           push: true
@@ -167,7 +167,7 @@ jobs:
         id: build_container_test_runner
         if: ${{ steps.deploy_endpoint.outcome == 'success' }}
         continue-on-error: true
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: ${{ env.ENDPOINT_REPO_PATH }}
           file: ${{ format('{0}/Dockerfile', env.ENDPOINT_REPO_HFJOBS_FOLDER_PATH) }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,12 +29,12 @@ jobs:
     name: fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           components: rustfmt
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
 
       # Check fmt
       - name: "rustfmt --check"
@@ -44,12 +44,12 @@ jobs:
     name: clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       # Run clippy
       - name: "clippy --all"
         run: cargo clippy --all --tests --all-features --no-deps
@@ -64,12 +64,12 @@ jobs:
   #          - os: ubuntu-latest
   #
   #    steps:
-  #      - uses: actions/checkout@v4
+  #      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
   #      - name: Install Rust ${{ env.rust_nightly }}
-  #        uses: dtolnay/rust-toolchain@stable
+  #        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
   #        with:
   #          toolchain: ${{ env.rust_nightly }}
-  #      - uses: Swatinem/rust-cache@v2
+  #      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
   #      - name: "doc --lib --all-features"
   #        run: |
   #          cargo doc --lib --no-deps --all-features --document-private-items
@@ -86,10 +86,10 @@ jobs:
         python: [ 3.12, 3.13 ]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: ${{ matrix.python }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Build
         run: cargo build --verbose
       - name: Run tests


### PR DESCRIPTION
## 🔒 Pin GitHub Actions to commit SHAs

This PR pins all GitHub Actions to their exact commit SHA instead of mutable tags or branch names.

**Why?**
Pinning to a SHA prevents supply chain attacks where a tag (e.g. `v4`) could be moved to point to malicious code.

### Changes

| Workflow | Action | Avant | Après | SHA |
|---|---|---|---|---|
| `integration.yml` | `actions/setup-python` | `v5` | `v5` | `a26af69be951…` |
| `integration.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `integration.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `integration.yml` | `actions-rust-lang/setup-rust-toolchain` | `v1` | `v1` | `150fca883cd4…` |
| `integration.yml` | `actions/cache` | `v4` | `v4` | `0057852bfaa8…` |
| `integration.yml` | `docker/login-action` | `v3` | `v3` | `c94ce9fb4685…` |
| `integration.yml` | `docker/metadata-action` | `v5` | `v5` | `c299e40c6544…` |
| `integration.yml` | `docker/build-push-action` | `v6` | `v6` | `10e90e3645ea…` |
| `integration.yml` | `docker/build-push-action` | `v6` | `v6` | `10e90e3645ea…` |
| `integration.yml` | `docker/build-push-action` | `v6` | `v6` | `10e90e3645ea…` |
| `rust.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `rust.yml` | `dtolnay/rust-toolchain` | `stable` | `stable` | `29eef336d9b2…` |
| `rust.yml` | `Swatinem/rust-cache` | `v2` | `v2` | `e18b497796c1…` |
| `rust.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `rust.yml` | `dtolnay/rust-toolchain` | `stable` | `stable` | `29eef336d9b2…` |
| `rust.yml` | `Swatinem/rust-cache` | `v2` | `v2` | `e18b497796c1…` |
| `rust.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `rust.yml` | `dtolnay/rust-toolchain` | `stable` | `stable` | `29eef336d9b2…` |
| `rust.yml` | `Swatinem/rust-cache` | `v2` | `v2` | `e18b497796c1…` |
| `rust.yml` | `actions/setup-python` | `v5` | `v5` | `a26af69be951…` |
| `rust.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |

> 🤖 Generated by `/github-actions-audit` — [security/pin-actions-to-sha]


Closes huggingface/tracking-issues#141